### PR TITLE
Fix autoprefixer script quoting

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "scripts": {
     "scss": "node-sass --output-style compressed -o assets/css assets/_scss",
-    "autoprefixer": "postcss -u autoprefixer -b \">, 5%, ie 9\" -r assets/css/*",
+    "autoprefixer": "postcss -u autoprefixer -b \"> 5%, ie 9\" -r assets/css/*",
     "uglify": "uglifyjs assets/js/vendor/jquery/jquery-1.12.1.min.js assets/js/plugins/jquery.fitvids.js assets/js/plugins/jquery.greedy-navigation.js assets/js/plugins/jquery.magnific-popup.js assets/js/plugins/jquery.smooth-scroll.min.js assets/js/plugins/stickyfill.min.js assets/js/_main.js -c -m -o assets/js/main.min.js",
     "watch:css": "onchange \"assets/_scss/**/*.scss\" -- npm run build:css",
     "watch:js": "onchange \"assets/js/**/*.js\" -e \"assets/js/main.min.js\" -- npm run build:js",


### PR DESCRIPTION
## Summary
- fix quoting for the autoprefixer build script

## Testing
- `npm install` *(fails: node-sass needs python2)*

------
https://chatgpt.com/codex/tasks/task_e_6845b98184948323ae24c7591ee5fa0a